### PR TITLE
Downgrade version for SyncroSim v2.4

### DIFF
--- a/Index.xml
+++ b/Index.xml
@@ -142,16 +142,16 @@
   </package>
   <package 
     name="omniscape" 
-    version="1.1.1" 
-    location="https://github.com/ApexRMS/omniscape/releases/download/1.1.1/omniscape-1-1-1.ssimpkg" 
+    version="1.1.0" 
+    location="https://github.com/ApexRMS/omniscape/releases/download/1.1.0/omniscape-1-1-0.ssimpkg" 
     type="Base" 
     description="Omni-directional habitat connectivity based on circuit theory" 
     url="https://apexrms.github.io/omniscape/">
   </package>
   <package 
     name="omniscapeImpact" 
-    version="1.0.1" 
-    location="https://github.com/ApexRMS/omniscapeImpact/releases/download/1.0.1/omniscapeImpact-1-0-1.ssimpkg" 
+    version="1.0.0" 
+    location="https://github.com/ApexRMS/omniscapeImpact/releases/download/1.0.0/omniscapeImpact-1-0-0.ssimpkg" 
     type="Add-on to omniscape" 
     description="Calculates changes in connectivity categories from a baseline" 
     requires="omniscape"

--- a/omniscape/metadata.xml
+++ b/omniscape/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package 
   name="omniscape" 
-  version="1.1.1" 
-  location="https://github.com/ApexRMS/omniscape/releases/download/1.1.1/omniscape-1-1-1.ssimpkg" 
+  version="1.1.0" 
+  location="https://github.com/ApexRMS/omniscape/releases/download/1.1.0/omniscape-1-1-0.ssimpkg" 
   type="Base" 
   description="Omni-directional habitat connectivity based on circuit theory" 
   url="https://apexrms.github.io/omniscape/">

--- a/omniscapeImpact/metadata.xml
+++ b/omniscapeImpact/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package 
   name="omniscapeImpact" 
-  version="1.0.1" 
-  location="https://github.com/ApexRMS/omniscapeImpact/releases/download/1.0.1/omniscapeImpact-1-0-1.ssimpkg" 
+  version="1.0.0" 
+  location="https://github.com/ApexRMS/omniscapeImpact/releases/download/1.0.0/omniscapeImpact-1-0-0.ssimpkg" 
   type="Add-on to omniscape" 
   description="Calculates changes in connectivity categories from a baseline" 
   requires="omniscape"


### PR DESCRIPTION
- Downgrading omniscape & omniscapeImpact versions for compatibility with SyncroSim versions 2.4